### PR TITLE
remove namespace from Deployment in index.yaml

### DIFF
--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -5415,7 +5415,6 @@ metadata:
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd-applicationset
   name: argocd-applicationset-controller
-  namespace: argocd
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Remove namespace from Deployment.

I was searching why I got an issue with the following patch and it was because of the namespace in kind Deployment
Looking into the install.yaml of argo-cd and others the difference is the namespace in kind: Deployment in index.yaml.

Two possible pathes:
1. remove the namespace from the Deployment (it is normally given/ overwritten with kustomize)
2. force users to add additional namespace: to the patch (else kustomize will fail and complain with the following message
```
no matches for Id apps_v1_Deployment|~X|argocd-applicationset-controller; failed to find unique target for patch apps_v1_Deployment|argocd-applicationset-controller"
```


```sh
cat > overlay/clusterX/kustomization.yaml <<EOM
kind: Kustomization
namespace: argocd
resources:
- ../../base/

patchesStrategicMerge:
- patch-limits.yaml
EOM

cat > overlay/clusterX/patch-limits.yaml << EOM
apiVersion: apps/v1
kind: Deployment
metadata:
  name: argocd-applicationset-controller
spec:
  template:
    spec:
      containers:
      - name: argocd-applicationset-controller
        resources:
          requests:
            cpu: 50m
            memory: 64Mi
EOM
```