### PR TITLE
docs: be explicit about which namespace appsets should be in (#476)

### DIFF
--- a/docs/Argo-CD-Integration.md
+++ b/docs/Argo-CD-Integration.md
@@ -10,6 +10,10 @@ Thus the ApplicationSet controller:
 - Does not connect to clusters other than the one Argo CD is deployed to
 - Does not interact with namespaces other than the one Argo CD is deployed within
 
+!!!important "Use the Argo CD namespace"
+    All ApplicationSet resources and the ApplicationSet controller must be installed in the same namespace as Argo CD. 
+    ApplicationSet resources in a different namespace will be ignored.
+
 It is Argo CD itself that is responsible for the actual deployment of the generated child `Application` resources, such as Deployments, Services, and ConfigMaps.
 
 The ApplicationSet controller can thus be thought of as an `Application` 'factory', taking an `ApplicationSet` resource as input, and outputting one or more Argo CD `Application` resources that correspond to the parameters of that set.

--- a/docs/Generators-Cluster-Decision-Resource.md
+++ b/docs/Generators-Cluster-Decision-Resource.md
@@ -6,6 +6,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
  name: guestbook
+ namespace: argocd
 spec:
  generators:
  - clusterDecisionResource:

--- a/docs/Generators-Cluster.md
+++ b/docs/Generators-Cluster.md
@@ -37,6 +37,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: guestbook
+  namespace: argocd
 spec:
   generators:
   - clusters: {} # Automatically use all clusters defined within Argo CD
@@ -64,6 +65,7 @@ A label selector may be used to narrow the scope of targeted clusters to only th
 kind: ApplicationSet
 metadata:
   name: guestbook
+  namespace: argocd
 spec:
   generators:
   - clusters:

--- a/docs/Generators-Git.md
+++ b/docs/Generators-Git.md
@@ -29,6 +29,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: cluster-addons
+  namespace: argocd
 spec:
   generators:
   - git:
@@ -73,6 +74,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: cluster-addons
+  namespace: argocd
 spec:
   generators:
   - git:
@@ -197,6 +199,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: guestbook
+  namespace: argocd
 spec:
   generators:
   - git:

--- a/docs/Generators-List.md
+++ b/docs/Generators-List.md
@@ -6,6 +6,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: guestbook
+  namespace: argocd
 spec:
   generators:
   - list:

--- a/examples/matrix/list-and-list.yaml
+++ b/examples/matrix/list-and-list.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: list-and-list
+  namespace: argocd
 spec:
   generators:
     - matrix:


### PR DESCRIPTION
Fixes #476 

I think hard-coding the `argocd` namespace will clarify more than confuse. People who are using non-standard namespaces will be more likely to know that they need to adjust these manifests.