### PR TITLE
feat: expose default metrics port in manifest definitions.

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -25,6 +25,8 @@ spec:
           ports:
           - containerPort: 7000
             name: webhook
+          - containerPort: 8080
+            name: metrics
           env:
             - name: NAMESPACE
               valueFrom:

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -12,5 +12,9 @@ spec:
     port: 7000
     protocol: TCP
     targetPort: webhook
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -6600,6 +6600,10 @@ spec:
     port: 7000
     protocol: TCP
     targetPort: webhook
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller
 ---
@@ -6635,6 +6639,8 @@ spec:
         ports:
         - containerPort: 7000
           name: webhook
+        - containerPort: 8080
+          name: metrics
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts


### PR DESCRIPTION
Fixes #495 

Out of the box, Applicationset presents some controller-runtime metrics on port 8080. However, the metric port is not defined as a container port in manifest files, therefore, they are not accessible. This commit aims to make it accessible.

Co-authored-by: Erkan Zileli <erkan.zileli@trendyol.com>