### PR TITLE
docs: Updating cascading strategy

### DIFF
--- a/docs/Application-Deletion.md
+++ b/docs/Application-Deletion.md
@@ -20,7 +20,7 @@ Thus the lifecycle of the `ApplicationSet`, the `Application`, and the `Applicat
 
 It *is* still possible to delete an `ApplicationSet` resource, while preventing `Application`s (and their deployed resources) from also being deleted, using a non-cascading delete:
 ```
-kubectl delete ApplicationSet (NAME) --cascade=false
+kubectl delete ApplicationSet (NAME) --cascade=orphan
 ```
 
 !!! warning


### PR DESCRIPTION
As per the [documentation](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#non-cascading-delete), if a resource should be deleted without deleting depending resources, the `orphan` cascading strategy should be used.