### PR TITLE
fix: handle empty github repos in SCM generator (#503)

### DIFF
--- a/pkg/services/scm_provider/github_test.go
+++ b/pkg/services/scm_provider/github_test.go
@@ -72,10 +72,10 @@ func TestGithubListRepos(t *testing.T) {
 			provider, _ := NewGithubProvider(context.Background(), "argoproj", "", "", c.allBranches)
 			rawRepos, err := provider.ListRepos(context.Background(), c.proto)
 			if c.hasError {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				checkRateLimit(t, err)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				// Just check that this one project shows up. Not a great test but better thing nothing?
 				repos := []*Repository{}
 				branches := []string{}


### PR DESCRIPTION
Fixes #503

I don't like not having any tests here. But adding a test would require creating an empty repo in, say, the argoproj org. Maybe we could create an argoproj-tests org @alexmt ?

At any rate, spot-check on gzur-org works, and this seems like a pretty safe change.