### PR TITLE
fix: Adding indirect dependency for errors pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect


### PR DESCRIPTION
There is indirect dependency for error pkg 
go mod tidy - added this dependecy adding to fix e2e test


Signed-off-by: rishabh625 <rishabhmishra625@gmail.com>