### PR TITLE
chore: Added 60s sleep between start e2e and test e2e,increased test …

### DIFF
--- a/.github/workflows/cron-master.yaml
+++ b/.github/workflows/cron-master.yaml
@@ -64,8 +64,9 @@ jobs:
           "hack/ci-e2e-setup.sh"
 
       - name: Run E2E tests
-        timeout-minutes: 20
+        timeout-minutes: 25
         run: |
+          sleep 60s
           cd "$GITHUB_WORKSPACE/applicationset"
           "hack/ci-e2e-run.sh"
 


### PR DESCRIPTION
**What this PR does:**

This PR increases the e2e test run timeout from 20 mins to 25 mins.

Adding a longer delay between start e2e and test e2e could solve the current "master cron" e2e test failure. The assumption is that the Github runner become slow sometimes and the delay is not longer enough to allow  e2e test application to start.