### PR TITLE
fix: downgrade Argo CD dependency to exclude argoproj/argocd#ca2e3041

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj/applicationset
 go 1.17
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.3.0
+	github.com/argoproj/argo-cd/v2 v2.3.0-rc5.0.20220225234205-31676e2aea6f
 	github.com/argoproj/gitops-engine v0.6.0
 	github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0
 	github.com/go-logr/logr v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/antonmedv/expr v1.8.9/go.mod h1:5qsM3oLGDND7sDmQGDXHkYfkjYMUX14qsgqmH
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/appscode/go v0.0.0-20190808133642-1d4ef1f1c1e0/go.mod h1:iy07dV61Z7QQdCKJCIvUoDL21u6AIceRhZzyleh2ymc=
-github.com/argoproj/argo-cd/v2 v2.3.0 h1:xr6UNI2EW08/eqEBM0Ue2GjpoS4bFOc0SADfhyI9zlo=
-github.com/argoproj/argo-cd/v2 v2.3.0/go.mod h1:PQw/102hk/8LmuMy0daLH1SIFYq3f95cUya+3NZP3xg=
+github.com/argoproj/argo-cd/v2 v2.3.0-rc5.0.20220225234205-31676e2aea6f h1:dZnUCDyc0dOWFDtxf7GuPIvTAPTPspDdx9GhziamGwo=
+github.com/argoproj/argo-cd/v2 v2.3.0-rc5.0.20220225234205-31676e2aea6f/go.mod h1:PQw/102hk/8LmuMy0daLH1SIFYq3f95cUya+3NZP3xg=
 github.com/argoproj/gitops-engine v0.6.0 h1:Tnh6kUUVuBV0m3gueYIymAeErWl9XNN9O9JcOoNM0vU=
 github.com/argoproj/gitops-engine v0.6.0/go.mod h1:pRgVpLW7pZqf7n3COJ7UcDepk4cI61LAcJd64Q3Jq/c=
 github.com/argoproj/notifications-engine v0.3.1-0.20220127183449-91deed20b998/go.mod h1:5mKv7zEgI3NO0L+fsuRSwBSY9EIXSuyIsDND8O8TTIw=

--- a/pkg/services/repo_service.go
+++ b/pkg/services/repo_service.go
@@ -44,7 +44,7 @@ func (a *argoCDService) GetFiles(ctx context.Context, repoURL string, revision s
 		return nil, fmt.Errorf("Error in GetRepository: %w", err)
 	}
 
-	gitRepoClient, err := git.NewClient(repo.Repo, repo.GetGitCreds(git.NoopCredsStore{}), repo.IsInsecure(), repo.IsLFSEnabled(), repo.Proxy)
+	gitRepoClient, err := git.NewClient(repo.Repo, repo.GetGitCreds(), repo.IsInsecure(), repo.IsLFSEnabled(), repo.Proxy)
 
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (a *argoCDService) GetDirectories(ctx context.Context, repoURL string, revi
 		return nil, fmt.Errorf("Error in GetRepository: %w", err)
 	}
 
-	gitRepoClient, err := git.NewClient(repo.Repo, repo.GetGitCreds(git.NoopCredsStore{}), repo.IsInsecure(), repo.IsLFSEnabled(), repo.Proxy)
+	gitRepoClient, err := git.NewClient(repo.Repo, repo.GetGitCreds(), repo.IsInsecure(), repo.IsLFSEnabled(), repo.Proxy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The https://github.com/argoproj/argo-cd/pull/8516 introduced an incompatible change in Argo CD that changes how repo credentials are passed to git. In order to accommodate this change, we would have to add `argocd` binary into applicationset image. This is too intrusive change, especially since we agreed to merge applicationset and argocd code. 

So I propose to temporary use pre v2.3 release version of Argo CD that does not have https://github.com/argoproj/argo-cd/pull/8516 and prioritize merging Application + Argo CD during v2.4 Argo CD .