### PR TITLE
fix: add missing git-ask-pass.sh to correctly access private git repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-
-FROM quay.io/argoproj/argocd:v2.3.0 as argocd
-
 # https://github.com/argoproj/argo-cd/pull/8516 now requires us to copy Argo CD binary into the ApplicationSet controller
 
 
@@ -36,8 +33,7 @@ RUN apt-get update && apt-get dist-upgrade -y && \
 # Add Argo CD helper scripts that are required by 'github.com/argoproj/argo-cd/util/git' package
 COPY hack/from-argo-cd/gpg-wrapper.sh /usr/local/bin/gpg-wrapper.sh
 COPY hack/from-argo-cd/git-verify-wrapper.sh /usr/local/bin/git-verify-wrapper.sh
-
-COPY --from=argocd /usr/local/bin/argocd /usr/local/bin/argocd
+COPY hack/from-argo-cd/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/hack/from-argo-cd/git-ask-pass.sh
+++ b/hack/from-argo-cd/git-ask-pass.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# This script is used as the command supplied to GIT_ASKPASS as a way to supply username/password
+# credentials to git, without having to use git credentials helpers, or having on-disk config.
+case "$1" in
+Username*) echo "${GIT_USERNAME}" ;;
+Password*) echo "${GIT_PASSWORD}" ;;
+esac


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR is a follow-up for https://github.com/argoproj/applicationset/pull/533 : introduces missing `git-ask-pass.sh` script that is required to access private git repositories.