### PR TITLE
docs(apptemplates): fix example on docs

### DIFF
--- a/docs/Generators-Git.md
+++ b/docs/Generators-Git.md
@@ -39,7 +39,7 @@ spec:
       - path: examples/git-generator-directory/cluster-addons/*
   template:
     metadata:
-      name: '{{path[0]}}'
+      name: '{{path.basename}}'
     spec:
       project: default
       source:


### PR DESCRIPTION
- tried copy pasting as the lazy a** I am and example on docs didn't work as expected.