### PR TITLE
docs(applicationset): update git generator example

### DIFF
--- a/docs/Generators-Git.md
+++ b/docs/Generators-Git.md
@@ -39,7 +39,7 @@ spec:
       - path: examples/git-generator-directory/cluster-addons/*
   template:
     metadata:
-      name: '{{path[0]}}'
+      name: '{{path.basename}}'
     spec:
       project: default
       source:


### PR DESCRIPTION
path[0] does not work with more than one application
path[0] ends up with all apps being called "example"

- tried copy pasting as the lazy a** I am and example on docs didn't work as expected.
- path.basename is easy thus very predictable.