### PR TITLE
chore: Upgrade docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 
 # Build the binary
-FROM docker.io/library/golang:1.17.6 as builder
+FROM docker.io/library/golang:1.17 as builder
 
 WORKDIR /workspace
 
@@ -21,7 +21,7 @@ RUN rm -f ./bin/*
 # Build
 RUN make build
 
-FROM docker.io/library/ubuntu:21.10
+FROM docker.io/library/ubuntu:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get dist-upgrade -y && \


### PR DESCRIPTION
We want to have the latest ubuntu security fixes without needing an update in this dockerfile.
We also want to use the latest 1.17 golang image at the build time for the same reason.
