### PR TITLE
requeueAfterSeconds was incorrectly placed

### DIFF
--- a/docs/Generators-Pull-Request.md
+++ b/docs/Generators-Pull-Request.md
@@ -42,7 +42,7 @@ spec:
         # Labels is used to filter the PRs that you want to target. (optional)
         labels:
         - preview
-  requeueAfterSeconds: 1800
+      requeueAfterSeconds: 1800
   template:
   # ...
 ```


### PR DESCRIPTION
When I run the example, I get an error because `requeueAfterSeconds` is misplaced. When I moved like the PR then it worked, so I am assuming is not in the correct place in docs.