### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/cron-master-on-stable.yaml
+++ b/.github/workflows/cron-master-on-stable.yaml
@@ -37,14 +37,14 @@ jobs:
         run: |
           LATEST_RELEASE=`gh release list --repo argoproj/argo-cd | grep "$RELEASE_LIST_SEARCH_STRING" | head -n 1 | cut -f 1`
           echo Latest release for $RELEASE_LIST_SEARCH_STRING is $LATEST_RELEASE
-          echo "::set-output name=latestRelease::$LATEST_RELEASE"
+          echo "latestRelease=$LATEST_RELEASE" >> $GITHUB_OUTPUT
 
       - name: Call GitHub CLI to find latest stable ApplicationSet release
         id: get-appset-stable
         run: |
           LATEST_RELEASE=`gh release list --repo argoproj-labs/applicationset | grep "Latest" | cut -f 1`
           echo Latest release for ApplicationSet is $LATEST_RELEASE
-          echo "::set-output name=latestRelease::$LATEST_RELEASE"
+          echo "latestRelease=$LATEST_RELEASE" >> $GITHUB_OUTPUT
 
 
       - name: Checkout latest Argo CD code

--- a/.github/workflows/cron-stable-on-stable.yaml
+++ b/.github/workflows/cron-stable-on-stable.yaml
@@ -36,14 +36,14 @@ jobs:
         run: |
           LATEST_RELEASE=`gh release list --repo argoproj/argo-cd | grep "$RELEASE_LIST_SEARCH_STRING" | head -n 1 | cut -f 1`
           echo Latest release for $RELEASE_LIST_SEARCH_STRING is $LATEST_RELEASE
-          echo "::set-output name=latestRelease::$LATEST_RELEASE"
+          echo "latestRelease=$LATEST_RELEASE" >> $GITHUB_OUTPUT
 
       - name: Call GitHub CLI to find latest stable ApplicationSet release
         id: get-appset-stable
         run: |
           LATEST_RELEASE=`gh release list --repo argoproj-labs/applicationset | grep "Latest" | cut -f 1`
           echo Latest release for ApplicationSet is $LATEST_RELEASE
-          echo "::set-output name=latestRelease::$LATEST_RELEASE"
+          echo "latestRelease=$LATEST_RELEASE" >> $GITHUB_OUTPUT
 
 
       - name: Checkout latest Argo CD code


### PR DESCRIPTION
## Description

Resolve  #635 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=latestRelease::$LATEST_RELEASE"
```

**TO-BE**

```yaml
echo "latestRelease=$LATEST_RELEASE" >> $GITHUB_OUTPUT
```