### PR TITLE
add a organizationNormalized template value for SCM provider

### DIFF
--- a/docs/Generators-SCM-Provider.md
+++ b/docs/Generators-SCM-Provider.md
@@ -187,6 +187,7 @@ spec:
 ```
 
 * `organization`: The name of the organization the repository is in.
+* `organizationNormalized`: The `name` of the organization the repository is in *but normalized to contain only lowercase alphanumeric characters, '-' or '.'*.
 * `repository`: The name of the repository.
 * `url`: The clone URL for the repository.
 * `branch`: The default branch of the repository.

--- a/pkg/generators/scm_provider.go
+++ b/pkg/generators/scm_provider.go
@@ -98,12 +98,13 @@ func (g *SCMProviderGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha
 	params := make([]map[string]string, 0, len(repos))
 	for _, repo := range repos {
 		params = append(params, map[string]string{
-			"organization": repo.Organization,
-			"repository":   repo.Repository,
-			"url":          repo.URL,
-			"branch":       repo.Branch,
-			"sha":          repo.SHA,
-			"labels":       strings.Join(repo.Labels, ","),
+			"organization":           repo.Organization,
+			"organizationNormalized": sanitizeName(repo.Organization),
+			"repository":             repo.Repository,
+			"url":                    repo.URL,
+			"branch":                 repo.Branch,
+			"sha":                    repo.SHA,
+			"labels":                 strings.Join(repo.Labels, ","),
 		})
 	}
 	return params, nil

--- a/pkg/generators/scm_provider_test.go
+++ b/pkg/generators/scm_provider_test.go
@@ -97,6 +97,13 @@ func TestSCMProviderGenerateParams(t *testing.T) {
 				Branch:       "main",
 				SHA:          "00000000",
 			},
+			{
+				Organization: "myorg/myteam",
+				Repository:   "repo3",
+				URL:          "git@github.com:myorg/myteam/repo2.git",
+				Branch:       "main",
+				SHA:          "00000000",
+			},
 		},
 	}
 	gen := &SCMProviderGenerator{overrideProvider: mockProvider}
@@ -106,6 +113,8 @@ func TestSCMProviderGenerateParams(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, params, 2)
 	assert.Equal(t, "myorg", params[0]["organization"])
+	assert.Equal(t, "myorg", params[0]["organizationNormalized"])
+	assert.Equal(t, "myorg/myteam", params[2]["organizationNormalized"])
 	assert.Equal(t, "repo1", params[0]["repository"])
 	assert.Equal(t, "git@github.com:myorg/repo1.git", params[0]["url"])
 	assert.Equal(t, "main", params[0]["branch"])


### PR DESCRIPTION
From the issue https://github.com/argoproj/applicationset/issues/640

This MR adds a `organizationNormalized` parameter to the SCM provider to ensure we can then use the Org name in templates